### PR TITLE
🐛 공간 쿼리 union 수정

### DIFF
--- a/search/views/search_views.py
+++ b/search/views/search_views.py
@@ -1,7 +1,3 @@
-from functools import reduce
-
-from django.contrib.gis.db.models.aggregates import Union
-from django.contrib.gis.measure import D
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
 from django.db.models.expressions import Exists, OuterRef

--- a/search/views/search_views.py
+++ b/search/views/search_views.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 from django.contrib.gis.db.models.aggregates import Union
 from django.contrib.gis.measure import D
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
@@ -99,13 +101,11 @@ class SearchView(View):
                     buffered_regions.append(district.geometry.buffer(3000))
 
             if buffered_regions:
-                # 버퍼 처리된 폴리곤들을 Union
-                regions_3km = (
-                    buffered_regions[0].union(*buffered_regions[1:])
-                    if len(buffered_regions) > 1
-                    else buffered_regions[0]
-                )
-                qs = qs.filter(location__dwithin=(regions_3km, D(km=0)))
+                # 버퍼 처리된 폴리곤들을 순차적으로 Union
+                regions_3km = buffered_regions[0]
+                for region in buffered_regions[1:]:
+                    regions_3km = regions_3km.union(region)
+                qs = qs.filter(location__within=regions_3km)
 
         # 7. 북마크 여부
         if current_user:


### PR DESCRIPTION
# 변경점
- 기존 공간 쿼리를 합치는 과정에서 3개 이상의 공간 데이터를 합치는데 문제 발생 / GEOS union은 인자를 2개밖에 받지 못함
- 순차적으로 합치기 위해 반복문 사용