### PR TITLE
🐛 지역필터 동명지역 검색 버그 수정

### DIFF
--- a/search/views/search_views.py
+++ b/search/views/search_views.py
@@ -87,7 +87,7 @@ class SearchView(View):
         if query.city_no:
             qs = qs.filter(city__in=city_code_to_name.values())
         if query.district_no:
-            qs = qs.filter(district__in=district_code_to_name.values())
+            qs = qs.filter(city__in=city_code_to_name.values(), district__in=district_code_to_name.values())
         # 6. 공간 필터링 (읍면동 기준, 3km 반경)
         if query.town_no and district_filter:
             buffered_regions = []


### PR DESCRIPTION
시군구 검색 시  다른 시, 도의 동명 구가 검색되는 버그를 수정 

-  시군구 정보 매핑만 사용 -> 시, 도 정보 매핑 추가